### PR TITLE
Fix Arduino Uno R3 could not connect to battery.

### DIFF
--- a/Arduino/SmartBatteryHack/SmartBatteryHack.ino
+++ b/Arduino/SmartBatteryHack/SmartBatteryHack.ino
@@ -32,7 +32,7 @@
     #define SCL_PORT PORTD
     #define SCL_PIN 1
 #endif
-
+#define I2C_PULLUP 1
 #define I2C_SLOWMODE 1 // 25 kHz
 #include <SoftI2CMaster.h>
 


### PR DESCRIPTION
The Arduino Uno R3 could not connect to battery: the com port no respond.
Fixes #1 